### PR TITLE
fix: prevent inserting payments with invalid dates

### DIFF
--- a/composeApp/src/androidMain/res/xml/network_security_config.xml
+++ b/composeApp/src/androidMain/res/xml/network_security_config.xml
@@ -3,7 +3,7 @@
     <!-- Allow cleartext traffic for development -->
     <domain-config cleartextTrafficPermitted="true">
         <!-- Local development domains -->
-        <domain includeSubdomains="true">192.168.1.11</domain>
+        <domain includeSubdomains="true">192.168.1.30</domain>
         <!-- Add your local IP here for testing: 192.168.x.x -->
     </domain-config>
 </network-security-config>

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/domain/usecases/bill/IInsertMissingPayments.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/domain/usecases/bill/IInsertMissingPayments.kt
@@ -3,6 +3,7 @@ package br.com.noartcode.theprice.domain.usecases.bill
 import br.com.noartcode.theprice.domain.model.Bill
 import br.com.noartcode.theprice.domain.model.DayMonthAndYear
 import br.com.noartcode.theprice.domain.model.Payment
+import br.com.noartcode.theprice.domain.model.isValid
 import br.com.noartcode.theprice.domain.model.toEpochMilliseconds
 import br.com.noartcode.theprice.domain.repository.BillsRepository
 import br.com.noartcode.theprice.domain.repository.PaymentsRepository
@@ -39,10 +40,17 @@ class InsertMissingPayments(
         val timeStamp = getTodayDate().toEpochMilliseconds()
         for (bill in bills) {
             if (existingPayments.containsKey(bill.id).not()) {
+
+                // TODO: Search for a better way to find a valid due date
+                var dueDate:DayMonthAndYear = date.copy(day = bill.billingStartDate.day)
+                while(dueDate.isValid().not()) {
+                    dueDate = dueDate.copy(day = dueDate.day - 1)
+                }
+
                 paymentsToAdd.add(
                     Payment(
                         billId = bill.id,
-                        dueDate = date.copy(day = bill.billingStartDate.day),
+                        dueDate = dueDate,
                         price = bill.price,
                         isPayed = false,
                         createdAt = timeStamp,

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/mapper/PaymentUiMapper.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/mapper/PaymentUiMapper.kt
@@ -28,14 +28,7 @@ class PaymentDomainToUiMapper (
         val bill = dataSource.getBill(from.billId) ?: return null
         return if (!from.isPayed) {
 
-            // TODO: Find a better way to calculate a valid end day
-            val start = getTodayDate()
-            var end:DayMonthAndYear = from.dueDate.copy(day = bill.billingStartDate.day)
-            while(end.isValid().not()) {
-                end = end.copy(day = bill.billingStartDate.day - 1)
-            }
-
-            val days = getDaysUntil(startDate = start, endDate = end)
+            val days = getDaysUntil(startDate = getTodayDate() , endDate = from.dueDate)
 
             val (description, status) = when {
                 days > 0 -> { "Expires in $days days" to PaymentUi.Status.PENDING }

--- a/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/domain/usecases/InsertMissingPaymentsTest.kt
+++ b/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/domain/usecases/InsertMissingPaymentsTest.kt
@@ -124,4 +124,28 @@ class InsertMissingPaymentsTest : KoinTest, RobolectricTests() {
 
     }
 
+
+    @Test
+    fun `Should insert missing payments with valid due dates`() = runTest {
+
+        // GIVEN
+        // A bill with start date at 01/31/2026 — A valid date
+        val date = DayMonthAndYear(day = 31, month = 1, year = 2026)
+        val bill = stubBills[0].copy(billingStartDate = date)
+
+        insertBill(bill)
+
+        // WHEN
+        // Inserting the payment of February
+        insertMissingPayments(date.copy(month = 2))
+
+        // THEN
+        // The February payment should be added with the next valid day (which in this case, should be 28)
+        val payment = paymentDataSource.getMonthPayments(month = 2, year = 2026).first().first()
+        assertEquals(
+            expected = 28,
+            actual = payment.dueDate.day
+        )
+    }
+
 }

--- a/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/ui/presentation/home/HomeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/ui/presentation/home/HomeViewModelTest.kt
@@ -380,7 +380,7 @@ class HomeViewModelTest : KoinTest, RobolectricTests() {
 
         assertTrue(result is Resource.Success)
 
-        // Set Current Day to November 21th
+        // Set Current Day to November 21st
         (getTodayDate as GetTodayDateStub).date =  DayMonthAndYear(day = 21, month = 11, year = 2024)
 
         viewModel.uiState.test {
@@ -448,7 +448,7 @@ class HomeViewModelTest : KoinTest, RobolectricTests() {
             with(updatedPayment) {
                 assertEquals(expected = PaymentUi.Status.OVERDUE, status)
                 assertEquals(expected = "R$ 100,00", actual = price)
-                assertEquals(expected = "9 days overdue", actual = statusDescription)
+                assertEquals(expected = "16 days overdue", actual = statusDescription)
             }
         }
     }


### PR DESCRIPTION
### PR Implements:
- Fix that prevents adding a payment with a invalid date.