### PR TITLE
Refactor/missing mechanics on edit payment

### DIFF
--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/domain/usecases/bill/IInsertBillWithPayments.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/domain/usecases/bill/IInsertBillWithPayments.kt
@@ -47,6 +47,7 @@ class InsertBillWithPayments(
         }
 
         // If no payments, it should create them.
+        // TODO("Change this logic to count the months difference not the date")
         try {
             val start = bill.billingStartDate.toLocalDate()
             val numOfPayments = start.until(

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/domain/usecases/payment/IUpdatePayment.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/domain/usecases/payment/IUpdatePayment.kt
@@ -1,7 +1,9 @@
 package br.com.noartcode.theprice.domain.usecases.payment
 
 import br.com.noartcode.theprice.domain.model.Payment
+import br.com.noartcode.theprice.domain.model.toEpochMilliseconds
 import br.com.noartcode.theprice.domain.repository.PaymentsRepository
+import br.com.noartcode.theprice.domain.usecases.datetime.IGetTodayDate
 import br.com.noartcode.theprice.util.Resource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,20 +11,25 @@ import kotlinx.coroutines.withContext
 interface IUpdatePayment {
     suspend operator fun invoke(
         payment: Payment
-    ) : Resource<Unit>
+    ) : Resource<Payment>
 }
 
 
 class UpdatePayment(
     private val repository: PaymentsRepository,
     private val dispatcher: CoroutineDispatcher,
+    private val getTodayDate: IGetTodayDate,
 ) : IUpdatePayment {
     override suspend fun invoke(
         payment: Payment
-    ): Resource<Unit> = withContext(dispatcher) {
+    ): Resource<Payment> = withContext(dispatcher) {
         try {
-            repository.update(payment)
-            return@withContext Resource.Success(Unit)
+            val updatedPayment = payment.copy(
+                updatedAt = getTodayDate().toEpochMilliseconds(),
+                isSynced = false
+            )
+            repository.update(updatedPayment)
+            return@withContext Resource.Success(updatedPayment)
         } catch (e:Throwable) {
             return@withContext Resource.Error(
                 message = "Error when tried to update payment",

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/di/CommonModule.kt
@@ -248,6 +248,7 @@ fun viewModelsModule() = module {
             paymentUiMapper = get(),
             getTodayDate = get(),
             eventSyncQueue = get(),
+            savedStateHandle = get(),
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/di/CommonModule.kt
@@ -144,7 +144,7 @@ fun commonModule() = module {
     single<IInsertPayments> { IInsertPayments(get<PaymentsRepository>()::insert) }
     single<IGetPayments> { GetPayments(billsRepository = get(), paymentsRepository = get(), ioDispatcher = get()) }
     single<IGetPaymentByID> { IGetPaymentByID(get<PaymentLocalDataSource>()::getPayment) }
-    single<IUpdatePayment> { UpdatePayment(repository = get(), dispatcher = get()) }
+    single<IUpdatePayment> { UpdatePayment(repository = get(), dispatcher = get(), getTodayDate = get()) }
     single<IUpdatePaymentStatus> { UpdatePaymentStatus(repository = get(), dispatcher = get()) }
     single<IGetOldestPaymentRecordDate> { GetOldestPaymentRecordDate(repository = get(), epochFormatter = get() ) }
     single<BillsRepository> { BillsRepositoryImp(local = get(), remote = get()) }
@@ -227,7 +227,6 @@ fun viewModelsModule() = module {
     viewModel {
         EditBillViewModel(
             currencyFormatter = get(),
-            updateBill = get(),
             getTodayDate = get(),
             getMonthName = get(),
             getBill = get(),
@@ -246,7 +245,7 @@ fun viewModelsModule() = module {
             currencyFormatter = get(),
             updatePayment = get(),
             paymentUiMapper = get(),
-            getTodayDate = get(),
+            updateBillAndApplyToPayments = get(),
             eventSyncQueue = get(),
             savedStateHandle = get(),
         )

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/bill/edit/EditBillViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/bill/edit/EditBillViewModel.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.launch
 
 class EditBillViewModel(
     private val currencyFormatter: ICurrencyFormatter,
-    private val updateBill: IUpdateBill,
     private val getTodayDate: IGetTodayDate,
     private val getMonthName: IGetMonthName,
     private val getBill: IGetBillByID,
@@ -170,23 +169,6 @@ class EditBillViewModel(
                 applyChangesToPayments(from = getTodayDate())
             }
         }
-    }
-
-    private suspend fun updateBillOnly() {
-        val changedBill = originalBill.copy(
-            description = _uiState.value.description,
-            billingStartDate = _uiState.value.billingStartDate
-        )
-
-        updateBill(changedBill)
-            .doIfSuccess { updatedBill ->
-                eventSyncQueue.enqueue(updatedBill.toSyncEvent("update"))
-                _uiState.update { it.copy(canClose = true) }
-            }
-            .doIfError { error ->
-                _uiState.update { it.copy(errorMessage = error.message) }
-                println("${error.message}, ${error.exception.toString()}" )
-            }
     }
 
     private suspend fun applyChangesToPayments(from: DayMonthAndYear?) {

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentEvent.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentEvent.kt
@@ -2,7 +2,7 @@ package br.com.noartcode.theprice.ui.presentation.payment.edit
 
 
 sealed interface EditPaymentEvent {
-    data class OnGetPayment(val id:String) : EditPaymentEvent
+   // data class OnGetPayment(val id:String) : EditPaymentEvent
     data class OnPriceChanged(val value:String) : EditPaymentEvent
     data class OnPaidAtDateChanged(val date:Long) : EditPaymentEvent
     data object OnStatusChanged : EditPaymentEvent

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentNavigation.kt
@@ -36,10 +36,10 @@ fun NavGraphBuilder.composeEditPaymentScreen(
             onNavigateBack = onNavigateBack,
         )
         //TODO("Retrieve the PaymentID inside the ViewModel")
-        LaunchedEffect(Unit){
+       /* LaunchedEffect(Unit){
             val id = entry.toRoute<EditPaymentDestination>().paymentId
             viewModel.onEvent(EditPaymentEvent.OnGetPayment(id))
-        }
+        }*/
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentUiState.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentUiState.kt
@@ -17,7 +17,8 @@ data class EditPaymentUiState(
     val priceHasChanged:Boolean = false,
     val dateHasChanged:Boolean = false,
     val statusHasChanged:Boolean = false,
+    val errorMessage:String? = null
 ) {
     val canSave: Boolean
-        get() = !priceHasError && (dateHasChanged || priceHasChanged || statusHasChanged)
+        get() = !priceHasError && errorMessage == null && (dateHasChanged || priceHasChanged || statusHasChanged)
 }

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
@@ -6,20 +6,21 @@ import androidx.lifecycle.viewModelScope
 import br.com.noartcode.theprice.data.local.mapper.toSyncEvent
 import br.com.noartcode.theprice.data.local.queues.EventSyncQueue
 import br.com.noartcode.theprice.domain.model.Bill
+import br.com.noartcode.theprice.domain.model.DayMonthAndYear
 import br.com.noartcode.theprice.domain.model.Payment
-import br.com.noartcode.theprice.domain.model.toEpochMilliseconds
 import br.com.noartcode.theprice.domain.usecases.ICurrencyFormatter
 import br.com.noartcode.theprice.domain.usecases.IEpochMillisecondsFormatter
 import br.com.noartcode.theprice.domain.usecases.bill.IGetBillByID
 import br.com.noartcode.theprice.domain.usecases.IGetDateFormat
+import br.com.noartcode.theprice.domain.usecases.bill.IUpdateBillAndApplyToPayments
 import br.com.noartcode.theprice.domain.usecases.payment.IGetPaymentByID
-import br.com.noartcode.theprice.domain.usecases.datetime.IGetTodayDate
 import br.com.noartcode.theprice.domain.usecases.payment.IUpdatePayment
 import br.com.noartcode.theprice.ui.mapper.UiMapper
 import br.com.noartcode.theprice.ui.presentation.home.PaymentUi
 import br.com.noartcode.theprice.ui.presentation.home.PaymentUi.Status.*
 import br.com.noartcode.theprice.util.doIfError
 import br.com.noartcode.theprice.util.doIfSuccess
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.onStart
@@ -35,18 +36,18 @@ class EditPaymentViewModel(
     private val epochFormatter: IEpochMillisecondsFormatter,
     private val updatePayment: IUpdatePayment,
     private val paymentUiMapper: UiMapper<Payment, PaymentUi?>,
-    private val getTodayDate: IGetTodayDate,
+    private val updateBillAndApplyToPayments: IUpdateBillAndApplyToPayments,
     private val eventSyncQueue: EventSyncQueue,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private var payment:Payment? = null
-    private var bill:Bill? = null
+    private lateinit var payment:Payment
+    private lateinit var bill:Bill
     private var paymentUi: PaymentUi? = null
 
 
-    private val _state = MutableStateFlow(EditPaymentUiState())
-    val uiState = _state
+    private val _uiState = MutableStateFlow(EditPaymentUiState())
+    val uiState = _uiState
         .onStart { setupPayment(savedStateHandle["paymentId"]) }
         .stateIn(
             scope = viewModelScope,
@@ -58,8 +59,8 @@ class EditPaymentViewModel(
         when(event){
 
             is EditPaymentEvent.OnPaidAtDateChanged -> {
-                val originalPaidDate = (payment!!.dueDate).let { date -> epochFormatter.from(date) }
-                _state.update {
+                val originalPaidDate = (payment.dueDate).let { date -> epochFormatter.from(date) }
+                _uiState.update {
                     it.copy(
                         paidAtDate = event.date,
                         paidDateTitle = dateFormatter(epochFormatter.to(event.date)),
@@ -71,7 +72,7 @@ class EditPaymentViewModel(
             is EditPaymentEvent.OnPriceChanged -> {
                 val value = currencyFormatter.clenup(event.value)
                 val newPrice = currencyFormatter.format(value)
-                _state.update {
+                _uiState.update {
                     it.copy(
                         payedValue = newPrice,
                         priceHasError = value == 0L,
@@ -81,8 +82,8 @@ class EditPaymentViewModel(
             }
 
             is EditPaymentEvent.OnStatusChanged -> {
-                val newStatus = generateNewPaymentStatus(_state.value.paymentStatus)
-                _state.update {
+                val newStatus = generateNewPaymentStatus(_uiState.value.paymentStatus)
+                _uiState.update {
                     it.copy(
                         paymentStatus =  newStatus,
                         statusHasChanged = newStatus != paymentUi!!.status
@@ -91,76 +92,86 @@ class EditPaymentViewModel(
             }
 
             EditPaymentEvent.OnSave -> {
-                if (_state.value.priceHasChanged) {
-                    _state.update {
-                        it.copy(
-                            askingConfirmation = true,
-                        )
-                    }
+                if (_uiState.value.priceHasChanged) {
+                    _uiState.update { it.copy(askingConfirmation = true) }
                 } else {
-                    _state.update {
-                        it.copy(
-                            isSaving = true
-                        )
-                    }
+                    _uiState.update { it.copy(isSaving = true) }
                     changeOnlyCurrentPayment()
                 }
-
             }
-
-            /*is EditPaymentEvent.OnGetPayment -> {
-                setupPayment(event.id)
-            }*/
 
 
             EditPaymentEvent.OnChangeAllFuturePayments -> {
-
+                _uiState.update { it.copy(askingConfirmation = false, isSaving = true) }
+                applyChangesToFuturePayments(from = payment.dueDate)
             }
 
             EditPaymentEvent.OnChangeOnlyCurrentPayment -> {
-                _state.update {
-                    it.copy(
-                        askingConfirmation = false,
-                        isSaving = true
-                    )
-                }
+                _uiState.update { it.copy(askingConfirmation = false, isSaving = true) }
                changeOnlyCurrentPayment()
             }
 
             EditPaymentEvent.OnDismissConfirmationDialog -> {
-                _state.update {
-                    it.copy(
-                        askingConfirmation = false,
-                    )
-                }
+                _uiState.update { it.copy(askingConfirmation = false) }
             }
         }
     }
 
     private suspend fun changeOnlyCurrentPayment() {
-        val p = Payment(
-            id = payment!!.id,
-            billId = payment!!.billId,
+       /* val p = Payment(
+            id = payment.id,
+            billId = payment.billId,
             price = currencyFormatter.clenup(_state.value.payedValue),
             dueDate =  epochFormatter.to(_state.value.paidAtDate),
             isPayed = _state.value.paymentStatus == PAYED,
-            createdAt = payment!!.createdAt,
+            createdAt = payment.createdAt,
             updatedAt = getTodayDate().toEpochMilliseconds(),
             isSynced = false,
+        )*/
+        val paymentToUpdate = payment.copy(
+            price = currencyFormatter.clenup(_uiState.value.payedValue),
+            isPayed = _uiState.value.paymentStatus == PAYED
         )
-        updatePayment(p).doIfSuccess {
-            eventSyncQueue.enqueue(p.toSyncEvent("update"))
-            _state.update { it.copy(isSaving = false, isSaved = true) }
-        }.doIfError {
-            // TODO ("LOG error on Crashlytics")
+        updatePayment(paymentToUpdate).doIfSuccess { updatedPayment ->
+            eventSyncQueue.enqueue(updatedPayment.toSyncEvent("update"))
+            _uiState.update { it.copy(isSaving = false, isSaved = true) }
+        }.doIfError { error ->
+            _uiState.update { it.copy(errorMessage = error.message, isSaving = false) }
         }
+    }
+
+    private suspend fun applyChangesToFuturePayments(from: DayMonthAndYear?) {
+        val priceInt = currencyFormatter.clenup(_uiState.value.payedValue)
+        val changedBill = bill.copy(
+            price = priceInt // the only bill info that this screen can change
+        )
+
+        // If status has changed, we should update the payment first
+        if (_uiState.value.statusHasChanged) {
+            val paymentToUpdate = payment.copy(
+                price = priceInt,
+                isPayed = _uiState.value.paymentStatus == PAYED
+            )
+            updatePayment(paymentToUpdate).doIfSuccess { updatedPayment ->
+                eventSyncQueue.enqueue(updatedPayment.toSyncEvent("update"))
+            }
+        }
+
+        updateBillAndApplyToPayments(changedBill, from)
+            .doIfSuccess { updatedBillWithPayments ->
+                eventSyncQueue.enqueue(updatedBillWithPayments.toSyncEvent("update"))
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            }
+            .doIfError { error ->
+                _uiState.update { it.copy(errorMessage = error.message, isSaving = false) }
+            }
     }
 
     private suspend fun generateNewPaymentStatus(status: PaymentUi.Status) : PaymentUi.Status =
         when(status) {
             OVERDUE, PENDING -> PAYED
             PAYED -> {
-                val paymentWithoutPaidDate = payment!!.copy(isPayed = false)
+                val paymentWithoutPaidDate = payment.copy(isPayed = false)
                 paymentUiMapper.mapFrom(paymentWithoutPaidDate)!!.status
             }
         }
@@ -168,26 +179,31 @@ class EditPaymentViewModel(
 
     private suspend fun setupPayment(paymentId:String?) {
         if (paymentId != null) {
-            payment = getPayment(paymentId)
-            bill = getBill(payment!!.billId)
-            paymentUi = paymentUiMapper.mapFrom(payment!!)
-            _state.update {
-                it.copy(
-                    billId = bill!!.id,
-                    billName = bill!!.name,
-                    payedValue = paymentUi!!.price,
-                    paidAtDate = payment!!.dueDate.let { date -> epochFormatter.from(date) },
-                    paidDateTitle = dateFormatter(payment!!.dueDate),
-                    paymentStatus = paymentUi!!.status,
-                )
+            try {
+                payment = getPayment(paymentId)!!
+                bill = getBill(payment.billId)!!
+                paymentUi = paymentUiMapper.mapFrom(payment)
+                _uiState.update {
+                    it.copy(
+                        billId = bill.id,
+                        billName = bill.name,
+                        payedValue = paymentUi!!.price,
+                        paidAtDate = payment.dueDate.let { date -> epochFormatter.from(date) },
+                        paidDateTitle = dateFormatter(payment.dueDate),
+                        paymentStatus = paymentUi!!.status,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(errorMessage ="Setup failed due to ${e.message}")
+                }
             }
         } else {
-            _state.update {
+            _uiState.update {
                 it.copy(
                     errorMessage = "paymentId is null"
                 )
             }
         }
-
     }
 }

--- a/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
@@ -1,5 +1,6 @@
 package br.com.noartcode.theprice.ui.presentation.payment.edit
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import br.com.noartcode.theprice.data.local.mapper.toSyncEvent
@@ -21,6 +22,7 @@ import br.com.noartcode.theprice.util.doIfError
 import br.com.noartcode.theprice.util.doIfSuccess
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -35,6 +37,7 @@ class EditPaymentViewModel(
     private val paymentUiMapper: UiMapper<Payment, PaymentUi?>,
     private val getTodayDate: IGetTodayDate,
     private val eventSyncQueue: EventSyncQueue,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private var payment:Payment? = null
@@ -43,11 +46,13 @@ class EditPaymentViewModel(
 
 
     private val _state = MutableStateFlow(EditPaymentUiState())
-    val uiState = _state.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = EditPaymentUiState()
-    )
+    val uiState = _state
+        .onStart { setupPayment(savedStateHandle["paymentId"]) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = EditPaymentUiState()
+        )
 
     fun onEvent(event: EditPaymentEvent) = viewModelScope.launch {
         when(event){
@@ -86,16 +91,26 @@ class EditPaymentViewModel(
             }
 
             EditPaymentEvent.OnSave -> {
-                _state.update {
-                    it.copy(
-                        askingConfirmation = true,
-                    )
+                if (_state.value.priceHasChanged) {
+                    _state.update {
+                        it.copy(
+                            askingConfirmation = true,
+                        )
+                    }
+                } else {
+                    _state.update {
+                        it.copy(
+                            isSaving = true
+                        )
+                    }
+                    changeOnlyCurrentPayment()
                 }
+
             }
 
-            is EditPaymentEvent.OnGetPayment -> {
+            /*is EditPaymentEvent.OnGetPayment -> {
                 setupPayment(event.id)
-            }
+            }*/
 
 
             EditPaymentEvent.OnChangeAllFuturePayments -> {
@@ -109,22 +124,7 @@ class EditPaymentViewModel(
                         isSaving = true
                     )
                 }
-                val p = Payment(
-                    id = payment!!.id,
-                    billId = payment!!.billId,
-                    price = currencyFormatter.clenup(_state.value.payedValue),
-                    dueDate =  epochFormatter.to(_state.value.paidAtDate),
-                    isPayed = _state.value.paymentStatus == PAYED,
-                    createdAt = payment!!.createdAt,
-                    updatedAt = getTodayDate().toEpochMilliseconds(),
-                    isSynced = false,
-                )
-                updatePayment(p).doIfSuccess {
-                    eventSyncQueue.enqueue(p.toSyncEvent("update"))
-                    _state.update { it.copy(isSaving = false, isSaved = true) }
-                }.doIfError {
-                    // TODO ("LOG error on Crashlytics")
-                }
+               changeOnlyCurrentPayment()
             }
 
             EditPaymentEvent.OnDismissConfirmationDialog -> {
@@ -134,6 +134,25 @@ class EditPaymentViewModel(
                     )
                 }
             }
+        }
+    }
+
+    private suspend fun changeOnlyCurrentPayment() {
+        val p = Payment(
+            id = payment!!.id,
+            billId = payment!!.billId,
+            price = currencyFormatter.clenup(_state.value.payedValue),
+            dueDate =  epochFormatter.to(_state.value.paidAtDate),
+            isPayed = _state.value.paymentStatus == PAYED,
+            createdAt = payment!!.createdAt,
+            updatedAt = getTodayDate().toEpochMilliseconds(),
+            isSynced = false,
+        )
+        updatePayment(p).doIfSuccess {
+            eventSyncQueue.enqueue(p.toSyncEvent("update"))
+            _state.update { it.copy(isSaving = false, isSaved = true) }
+        }.doIfError {
+            // TODO ("LOG error on Crashlytics")
         }
     }
 
@@ -147,19 +166,28 @@ class EditPaymentViewModel(
         }
 
 
-    private suspend fun setupPayment(paymentId:String) {
-        payment = checkNotNull(getPayment(paymentId))
-        bill = getBill(payment!!.billId)
-        paymentUi = paymentUiMapper.mapFrom(payment!!)
-        _state.update {
-            it.copy(
-                billId = bill!!.id,
-                billName = bill!!.name,
-                payedValue = paymentUi!!.price,
-                paidAtDate = payment!!.dueDate.let { date -> epochFormatter.from(date) },
-                paidDateTitle = dateFormatter(payment!!.dueDate),
-                paymentStatus = paymentUi!!.status,
-            )
+    private suspend fun setupPayment(paymentId:String?) {
+        if (paymentId != null) {
+            payment = getPayment(paymentId)
+            bill = getBill(payment!!.billId)
+            paymentUi = paymentUiMapper.mapFrom(payment!!)
+            _state.update {
+                it.copy(
+                    billId = bill!!.id,
+                    billName = bill!!.name,
+                    payedValue = paymentUi!!.price,
+                    paidAtDate = payment!!.dueDate.let { date -> epochFormatter.from(date) },
+                    paidDateTitle = dateFormatter(payment!!.dueDate),
+                    paymentStatus = paymentUi!!.status,
+                )
+            }
+        } else {
+            _state.update {
+                it.copy(
+                    errorMessage = "paymentId is null"
+                )
+            }
         }
+
     }
 }

--- a/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
+++ b/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
@@ -3,14 +3,12 @@ package br.com.noartcode.theprice.ui.presentation.payment.edit
 import app.cash.turbine.test
 import br.com.noartcode.theprice.data.helpers.stubBills
 import br.com.noartcode.theprice.data.local.ThePriceDatabase
-import br.com.noartcode.theprice.data.local.dao.PaymentDao
 import br.com.noartcode.theprice.data.local.queues.EventSyncQueue
 import br.com.noartcode.theprice.data.remote.dtos.BillWithPaymentsDto
 import br.com.noartcode.theprice.data.remote.dtos.PaymentDto
 import br.com.noartcode.theprice.domain.model.Bill
 import br.com.noartcode.theprice.domain.model.BillWithPayments
 import br.com.noartcode.theprice.domain.model.DayMonthAndYear
-import br.com.noartcode.theprice.domain.model.toEpochMilliseconds
 import br.com.noartcode.theprice.domain.usecases.bill.IInsertBillWithPayments
 import br.com.noartcode.theprice.ui.di.RobolectricTests
 import br.com.noartcode.theprice.ui.di.commonModule
@@ -19,7 +17,6 @@ import br.com.noartcode.theprice.ui.di.dispatcherTestModule
 import br.com.noartcode.theprice.ui.di.platformTestModule
 import br.com.noartcode.theprice.ui.di.useSavedStateHandle
 import br.com.noartcode.theprice.ui.di.viewModelsModule
-import br.com.noartcode.theprice.ui.presentation.home.PaymentUi.Status.PAYED
 import br.com.noartcode.theprice.util.Resource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -36,7 +33,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 
@@ -162,16 +158,18 @@ class EditPaymentViewModelTest : KoinTest, RobolectricTests() {
         val payment = billWithPayments.payments.last()
         useSavedStateHandle("paymentId" to payment.id)
 
+
+        // WHEN
         viewModel.uiState.test {
 
             skipItems(2)
 
             viewModel.onEvent(EditPaymentEvent.OnPriceChanged("R$ 120,9"))
-
             skipItems(1)
 
             viewModel.onEvent(EditPaymentEvent.OnSave)
 
+            // THEN
             with(awaitItem()) {
                 assertEquals(expected = true, actual = askingConfirmation)
                 assertEquals(expected = false, actual = isSaving)
@@ -179,6 +177,81 @@ class EditPaymentViewModelTest : KoinTest, RobolectricTests() {
             }
 
             ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `When OnChangeAllFuturePayments bill and affected payments should be updated`() = runTest {
+        // GIVEN
+        val billWithPayments = initBill(stubBills[0].copy(billingStartDate = billingStartDate))
+        // Passing the payment id to the ViewModel SavedStateHandle
+        val payment = billWithPayments.payments[1]
+        useSavedStateHandle("paymentId" to payment.id)
+
+        // WHEN
+        viewModel.uiState.test {
+
+            skipItems(2)
+
+            viewModel.onEvent(EditPaymentEvent.OnPriceChanged("R$ 120,9"))
+            skipItems(1)
+
+            viewModel.onEvent(EditPaymentEvent.OnChangeAllFuturePayments)
+            skipItems(2)
+
+            ensureAllEventsConsumed()
+
+            val event = eventSyncQueue.peek()!!
+            val (bill, payments) = Json.decodeFromString<BillWithPaymentsDto>(event.payload)
+
+            assertEquals(expected = 1, eventSyncQueue.size())
+            assertEquals(expected = "update", actual = event.action)
+            assertEquals(expected = 1209L, actual = bill.price)
+            assertEquals(expected = 3, actual = billWithPayments.payments.size)
+            assertEquals(expected = 2, actual = payments.size)
+            assertTrue { payments.all { it.price == 1209L }}
+        }
+    }
+
+    @Test
+    fun `When OnChangeAllFuturePayments payment status should be update after bill and payments`() = runTest {
+        // GIVEN
+        val billWithPayments = initBill(stubBills[0].copy(billingStartDate = billingStartDate))
+        // Passing the payment id to the ViewModel SavedStateHandle
+        val payment = billWithPayments.payments[1]
+        useSavedStateHandle("paymentId" to payment.id)
+
+        // WHEN
+        viewModel.uiState.test {
+
+            skipItems(2)
+
+            viewModel.onEvent(EditPaymentEvent.OnPriceChanged("R$ 120,9"))
+            skipItems(1)
+
+            viewModel.onEvent(EditPaymentEvent.OnStatusChanged)
+            skipItems(1)
+
+            viewModel.onEvent(EditPaymentEvent.OnChangeAllFuturePayments)
+            skipItems(2)
+
+            ensureAllEventsConsumed()
+
+            val paymentEvent = eventSyncQueue.peek()!!
+            val paymentToSync = Json.decodeFromString<PaymentDto>(paymentEvent.payload)
+
+            assertEquals(expected = 2, eventSyncQueue.size()) // two events
+            assertEquals(expected = "update", actual = paymentEvent.action)
+            assertEquals(expected = true, actual = paymentToSync.isPayed)
+
+            eventSyncQueue.remove(paymentEvent.id)
+            val billWithPaymentsEvent = eventSyncQueue.peek()!!
+            val (_, payments) = Json.decodeFromString<BillWithPaymentsDto>(billWithPaymentsEvent.payload)
+
+            assertEquals(expected = "update", actual = billWithPaymentsEvent.action)
+            assertEquals(expected = 2, payments.size)
+            assertEquals(expected = true, payments[0].isPayed)
+            assertEquals(expected = false, payments[1].isPayed)
         }
     }
 

--- a/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
+++ b/composeApp/src/commonTest/kotlin/br/com/noartcode/theprice/ui/presentation/payment/edit/EditPaymentViewModel.kt
@@ -1,0 +1,195 @@
+package br.com.noartcode.theprice.ui.presentation.payment.edit
+
+import app.cash.turbine.test
+import br.com.noartcode.theprice.data.helpers.stubBills
+import br.com.noartcode.theprice.data.local.ThePriceDatabase
+import br.com.noartcode.theprice.data.local.dao.PaymentDao
+import br.com.noartcode.theprice.data.local.queues.EventSyncQueue
+import br.com.noartcode.theprice.data.remote.dtos.BillWithPaymentsDto
+import br.com.noartcode.theprice.data.remote.dtos.PaymentDto
+import br.com.noartcode.theprice.domain.model.Bill
+import br.com.noartcode.theprice.domain.model.BillWithPayments
+import br.com.noartcode.theprice.domain.model.DayMonthAndYear
+import br.com.noartcode.theprice.domain.model.toEpochMilliseconds
+import br.com.noartcode.theprice.domain.usecases.bill.IInsertBillWithPayments
+import br.com.noartcode.theprice.ui.di.RobolectricTests
+import br.com.noartcode.theprice.ui.di.commonModule
+import br.com.noartcode.theprice.ui.di.commonTestModule
+import br.com.noartcode.theprice.ui.di.dispatcherTestModule
+import br.com.noartcode.theprice.ui.di.platformTestModule
+import br.com.noartcode.theprice.ui.di.useSavedStateHandle
+import br.com.noartcode.theprice.ui.di.viewModelsModule
+import br.com.noartcode.theprice.ui.presentation.home.PaymentUi.Status.PAYED
+import br.com.noartcode.theprice.util.Resource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditPaymentViewModelTest : KoinTest, RobolectricTests() {
+    private val testDispatcher: CoroutineDispatcher by inject()
+    private val database: ThePriceDatabase by inject()
+    private val insertBillWithPayments: IInsertBillWithPayments by inject()
+    private val eventSyncQueue: EventSyncQueue by inject()
+
+    private val billingStartDate = DayMonthAndYear(day = 15, month = 1, year = 2026)
+    private val currentDate = DayMonthAndYear(day = 8, month = 4, year = 2026)
+
+    // Unit Under Test
+    private val viewModel: EditPaymentViewModel by inject()
+
+
+    @BeforeTest
+    fun before() {
+        startKoin {
+            modules(
+                platformTestModule(),
+                commonModule(),
+                dispatcherTestModule(),
+                commonTestModule(),
+                viewModelsModule()
+            )
+        }
+        Dispatchers.setMain(testDispatcher)
+    }
+
+
+    @AfterTest
+    fun after() {
+        database.close()
+        Dispatchers.resetMain()
+        stopKoin()
+    }
+
+
+    @Test
+    fun `When the ViewModel started it should return the correct payment information`() = runTest {
+
+        // GIVEN
+        val billWithPayments = initBill(stubBills[0].copy(billingStartDate = billingStartDate))
+        // Passing the payment id to the ViewModel SavedStateHandle
+        val payment = billWithPayments.payments.last()
+        useSavedStateHandle("paymentId" to payment.id)
+
+
+        // WHEN
+        viewModel.uiState.test {
+
+            skipItems(1)
+
+            // THEN
+            with(awaitItem()) {
+                assertEquals(expected = payment.billId, actual = billId)
+                assertEquals(expected = "R$ 120,99", actual = payedValue)
+                assertEquals(expected = "15/03/2026", actual = paidDateTitle)
+                assertEquals(expected = false, actual = isSaved)
+                assertEquals(expected = false, actual = askingConfirmation)
+                assertEquals(expected = false, actual = priceHasError)
+                assertEquals(expected = false, actual = priceHasChanged)
+                assertEquals(expected = false, actual = dateHasChanged)
+                assertEquals(expected = false, actual = statusHasChanged)
+                assertEquals(expected = null, actual = errorMessage)
+            }
+
+            ensureAllEventsConsumed()
+        }
+
+
+    }
+
+    @Test
+    fun `When status has changed the confirmation dialog should not appear`() = runTest {
+
+        // GIVEN
+        val billWithPayments = initBill(stubBills[0].copy(billingStartDate = billingStartDate))
+        // Passing the payment id to the ViewModel SavedStateHandle
+        val payment = billWithPayments.payments.last()
+        useSavedStateHandle("paymentId" to payment.id)
+
+        viewModel.uiState.test {
+
+            skipItems(2)
+
+            viewModel.onEvent(EditPaymentEvent.OnStatusChanged)
+
+            with(awaitItem()){
+                assertEquals(expected = true, actual = statusHasChanged)
+                assertEquals(expected = true, actual = canSave)
+            }
+
+            viewModel.onEvent(EditPaymentEvent.OnSave)
+
+            with(awaitItem()) {
+                assertEquals(expected = false, actual = askingConfirmation)
+                assertEquals(expected = true, actual = isSaving)
+            }
+
+            with(awaitItem()) {
+                assertEquals(expected = false, actual = isSaving)
+                assertEquals(expected = true, actual = isSaved)
+            }
+
+            ensureAllEventsConsumed()
+
+            val event = eventSyncQueue.peek()!!
+            val paymentToSync = Json.decodeFromString<PaymentDto>(event.payload)
+            assertEquals(expected = "update", actual = event.action)
+            assertEquals(expected = payment.id, actual =  paymentToSync.id)
+        }
+    }
+
+    @Test
+    fun `When price has changed the confirmation dialog should appear`() = runTest {
+
+        // GIVEN
+        val billWithPayments = initBill(stubBills[0].copy(billingStartDate = billingStartDate))
+        // Passing the payment id to the ViewModel SavedStateHandle
+        val payment = billWithPayments.payments.last()
+        useSavedStateHandle("paymentId" to payment.id)
+
+        viewModel.uiState.test {
+
+            skipItems(2)
+
+            viewModel.onEvent(EditPaymentEvent.OnPriceChanged("R$ 120,9"))
+
+            skipItems(1)
+
+            viewModel.onEvent(EditPaymentEvent.OnSave)
+
+            with(awaitItem()) {
+                assertEquals(expected = true, actual = askingConfirmation)
+                assertEquals(expected = false, actual = isSaving)
+                assertEquals(expected = "R$ 12,09", actual = payedValue)
+            }
+
+            ensureAllEventsConsumed()
+        }
+    }
+
+
+    private suspend fun initBill(bill: Bill) : BillWithPayments {
+        // Populating database with 1 bill.
+        return (insertBillWithPayments(
+            bill = bill,
+            currentDate = currentDate
+        ) as Resource.Success).data
+
+    }
+
+}


### PR DESCRIPTION
### PR contain the following changes
- Save payment status without showing confirmation dialog
- Apply changes to future payments